### PR TITLE
Move "symfony/var-dumper" to dev requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,12 @@
   },
   "require": {
     "php": ">=7.0",
-    "symfony/var-dumper": "^5.4",
     "psr/http-message": "^1.0",
     "guzzlehttp/guzzle": "^6.2",
     "league/oauth2-client": "^1.4",
     "laminas/laminas-diactoros": "^2.17"
+  },
+  "require-dev": {
+    "symfony/var-dumper": "^5.4|^6.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "php": ">=7.0",
     "psr/http-message": "^1.0",
-    "guzzlehttp/guzzle": "^6.2",
+    "guzzlehttp/guzzle": "^6.2|^7.0",
     "league/oauth2-client": "^1.4",
     "laminas/laminas-diactoros": "^2.17"
   },

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
   "require": {
     "php": ">=7.0",
     "psr/http-message": "^1.0",
-    "guzzlehttp/guzzle": "^6.2|^7.2",
+    "guzzlehttp/guzzle": "^6.2 || ^7.2",
     "league/oauth2-client": "^1.4",
     "laminas/laminas-diactoros": "^2.17"
   },
   "require-dev": {
-    "symfony/var-dumper": "^5.4|^6.0"
+    "symfony/var-dumper": "^5.4 || ^6.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "php": ">=7.0",
     "psr/http-message": "^1.0",
-    "guzzlehttp/guzzle": "^6.2|^7.0",
+    "guzzlehttp/guzzle": "^6.2|^7.2",
     "league/oauth2-client": "^1.4",
     "laminas/laminas-diactoros": "^2.17"
   },


### PR DESCRIPTION
The `symfony/var-dumper` package has been moved from the main requirements to the development requirements in composer.json. 
This change is made to avoid installation of development tools in production environment. 
It also adds compatibility with version 6.0 of `symfony/var-dumper`.

Makes this compatible with Laravel v9, v10

I am using this package and can not upgrade my Laravel version, so please merge this.

Thank you.