### PR TITLE
Fix wrong namespace definition for IsrsEndpoint

### DIFF
--- a/src/Endpoints/Receivables/Configuration/IsrsEndpoint.php
+++ b/src/Endpoints/Receivables/Configuration/IsrsEndpoint.php
@@ -1,7 +1,7 @@
 <?php
     declare(strict_types=1);
 
-    namespace smallinvoice\api2\Receivables\Configuration;
+    namespace smallinvoice\api2\Endpoints\Receivables\Configuration;;
 
     use smallinvoice\api2\Wrapper\Endpoints\Parameters\GetParameters;
     use smallinvoice\api2\Wrapper\Endpoints\Parameters\ListParameters;


### PR DESCRIPTION
This will fix a PHP auto loader problem causing a fatal file not found error:
'PHP Fatal error: Uncaught Error: Class "smallinvoice\api2\Receivables\Configuration\IsrsEndpoint" not found'