### PR TITLE
add some sort of error handling to ResponseFile saveTo function

### DIFF
--- a/src/Wrapper/Response/ResponseFile.php
+++ b/src/Wrapper/Response/ResponseFile.php
@@ -42,9 +42,12 @@
         /**
          * Saves file to location
          * @param $file
+         * @throws ResponseException
          */
         public function saveTo($file)
         {
-            file_put_contents($file, $this->response->getBody()->getContents());
+            if (!file_put_contents($file, $this->response->getBody()->getContents())) {
+                throw new ResponseException('could not save file');
+            }
         }
     }


### PR DESCRIPTION
When using the current saveTo function, there is no possible way to check if the file_put_contents function actually works.
So I added some basic error handling to this function.
It will throw an ResponseError if file_put_contents returns any value that evaluate to false!